### PR TITLE
Add Github controller and jwt helper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
 			<artifactId>jjwt-api</artifactId>
 			<version>0.10.5</version>
 		</dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.10.5</version>
+      <scope>runtime</scope>
+    </dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,28 @@
 			<artifactId>custom-war-packager-lib</artifactId>
 			<version>1.7</version>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.10.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.10.5</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>29.0-jre</version>
+		</dependency>
+		<dependency>
+			<groupId>org.kohsuke</groupId>
+			<artifactId>github-api</artifactId>
+			<version>1.106</version>
+		</dependency>
 	</dependencies>
   
 	<licenses>

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubController.java
@@ -6,15 +6,36 @@ import org.kohsuke.github.GHAppInstallation;
 import org.kohsuke.github.GHAppInstallationToken;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
-import static com.org.jenkins.custom.jenkins.distribution.service.GithubJwtHelper.createJWT;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
+import static com.org.jenkins.custom.jenkins.distribution.service.GithubJwtHelper.createJWT;
+import static com.org.jenkins.custom.jenkins.distribution.service.GithubJwtHelper.get;
+
+
+@RestController
+@CrossOrigin("*")
 public class GithubController {
 
-    private static String APP_IDENTIFIER="";
+    @Value("${APP_IDENTIFIER}")
+    private String getAppIdentifier;
+
+    @PostMapping(path = "/event_handler")
+    public void handleEvent(@RequestBody String requestBodyString) throws Exception {
+        System.out.println("Received event handler event");
+        String token = authenticateApplication();
+        System.out.println(token);
+    }
 
     @SuppressWarnings("deprecation")
-    private static String authenticateApplication() {
+    private String authenticateApplication() {
         try {
+            String APP_IDENTIFIER = getAppIdentifier.replaceAll("^\"+|\"+$", "");
             String jwtToken = createJWT(APP_IDENTIFIER, 600000);
             GitHub gitHubApp = new GitHubBuilder().withEndpoint("https://api.github.com").withJwtToken(jwtToken).build();
             GHApp app = gitHubApp.getApp();

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubController.java
@@ -1,0 +1,35 @@
+package com.org.jenkins.custom.jenkins.distribution.service;
+
+import java.util.List;
+import org.kohsuke.github.GHApp;
+import org.kohsuke.github.GHAppInstallation;
+import org.kohsuke.github.GHAppInstallationToken;
+import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import static com.org.jenkins.custom.jenkins.distribution.service.GithubJwtHelper.createJWT;
+
+public class GithubController {
+
+    private static String APP_IDENTIFIER="";
+
+    @SuppressWarnings("deprecation")
+    private static String authenticateApplication() {
+        try {
+            String jwtToken = createJWT(APP_IDENTIFIER, 600000);
+            GitHub gitHubApp = new GitHubBuilder().withEndpoint("https://api.github.com").withJwtToken(jwtToken).build();
+            GHApp app = gitHubApp.getApp();
+            List<GHAppInstallation> appInstallations = app.listInstallations().asList();
+            if (!appInstallations.isEmpty()) {
+                GHAppInstallation appInstallation = appInstallations.get(0);
+                GHAppInstallationToken appInstallationToken = appInstallation
+                    .createToken(appInstallation.getPermissions())
+                    .create();
+                return appInstallationToken.getToken();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubJwtHelper.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubJwtHelper.java
@@ -1,0 +1,50 @@
+package com.org.jenkins.custom.jenkins.distribution.service;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.Jwts;
+import java.io.File;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+import com.google.common.io.Files;
+
+
+public class GithubJwtHelper {
+
+    static PrivateKey get(String filename) throws Exception {
+        byte[] keyBytes = Files.toByteArray(new File(filename));
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePrivate(spec);
+    }
+
+    static String createJWT(String githubAppId, long ttlMillis) throws Exception {
+        //The JWT signature algorithm we will be using to sign the token
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+
+        long nowMillis = System.currentTimeMillis();
+        Date now = new Date(nowMillis);
+
+        //We will sign our JWT with our private key
+        Key signingKey = get("custom_distribution_private_key.der");
+
+        //Let's set the JWT Claims
+        JwtBuilder builder = Jwts.builder()
+            .setIssuedAt(now)
+            .setIssuer(githubAppId)
+            .signWith(signingKey, signatureAlgorithm);
+
+        //if it has been specified, let's add the expiration
+        if (ttlMillis > 0) {
+            long expMillis = nowMillis + ttlMillis;
+            Date exp = new Date(expMillis);
+            builder.setExpiration(exp);
+        }
+
+        //Builds the JWT and serializes it to a compact, URL-safe string
+        return builder.compact();
+    }
+}

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubJwtHelper.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/GithubJwtHelper.java
@@ -29,7 +29,7 @@ public class GithubJwtHelper {
         Date now = new Date(nowMillis);
 
         //We will sign our JWT with our private key
-        Key signingKey = get("custom_distribution_private_key.der");
+        Key signingKey = get("jenkins-custom-distribution-bot.der");
 
         //Let's set the JWT Claims
         JwtBuilder builder = Jwts.builder()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+APP_IDENTIFIER = "71744"


### PR DESCRIPTION
This PR adds a Github Controller and the required JWT helper. The JWT helper takes care of the signing of the private key and the controller takes care of authenticating the application. We would like to keep this PR separate from the Github Services that will follow.