### PR TITLE
Allow ~/.config/git/ignore to work inside src/**

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 HELP.md
 target/
 !.mvn/wrapper/maven-wrapper.jar
-!**/src/main/**
-!**/src/test/**
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
Use ~/.config/git/ignore to ignore editor specific temp files.

The problem with the current .gitignore is that no file can be ignored under `src/`. This is wrong. Some text editors will create temporary files under `src/`, and those temp files need to be ignored. The right place to ignore temporary files that are text editor specific is `~/.config/git/ignore`. In other words, the choice of a text editor is specific to a user, and not all users share the same text editor preferences. The change proposed allows ignore patterns in `~/.config/git/ignore` to work under the `src/` tree.