### PR TITLE
Pin maven Surefire Plugin, Add Maven Enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 			<artifactId>json</artifactId>
 			<version>20200518</version>
 		</dependency>
+		<!-- Why do we bundle the Maven Plugin??? -->
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>
 			<artifactId>maven-dependency-plugin</artifactId>
@@ -94,9 +95,113 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M5</version>
+				<configuration>
+					<!-- SUREFIRE-1226 workaround -->
+					<trimStackTrace>false</trimStackTrace>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.3.1,)</version>
+                  <message>3.3.1 required to at least look at .mvn/ if it exists.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8.0,)</version>
+                </requireJavaVersion>
+                <!-- TODO failing during incrementals deploy: MENFORCER-281
+                <requirePluginVersions>
+                  <banSnapshots>false</banSnapshots>
+                </requirePluginVersions>
+                -->
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                  </ignoredScopes>
+                  <excludes>
+                    <!-- Makes no sense to check core itself: -->
+                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                    <exclude>org.jenkins-ci.main:cli</exclude>
+                    <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
+                    <exclude>org.jenkins-ci:task-reactor</exclude>
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
+                    <exclude>com.google.code.findbugs:annotations</exclude>
+                    <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
+                  </excludes>
+                  <!-- To add exclusions in a Jenkins plugin, use:
+                  <plugin>
+                      <artifactId>maven-enforcer-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>display-info</id>
+                              <configuration>
+                                  <rules>
+                                      <enforceBytecodeVersion>
+                                          <excludes combine.children="append">
+                                              <exclude>…</exclude>
+                                          </excludes>
+                                      </enforceBytecodeVersion>
+                                  </rules>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  (or just override java.level) -->
+                </enforceBytecodeVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.servlet:servlet-api</exclude>
+                    <exclude>org.sonatype.sisu:sisu-guice</exclude>
+                    <exclude>log4j:log4j:*:jar:compile</exclude>
+                    <exclude>log4j:log4j:*:jar:runtime</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                    <!-- Jenkins Test Harness is based on JUnit. Adding TestNG dependency would disable some of its functionality. -->
+                    <exclude>org.testng:testng</exclude>
+                  </excludes>
+                </bannedDependencies>
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>com.google.guava:guava</exclude> <!-- TODO needed for Jenkins 2.71 and earlier -->
+                    <exclude>commons-logging:commons-logging</exclude> <!-- ditto -->
+                    <exclude>com.google.code.findbugs:jsr305</exclude> <!-- ditto -->
+                    <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
+                  </excludes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+          </execution>
+		          </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
@@ -1,5 +1,6 @@
 package com.org.jenkins.custom.jenkins.distribution.service;
 
+import com.org.jenkins.custom.jenkins.distribution.service.services.PackagerDownloadService;
 import java.util.logging.Logger;
 import org.json.JSONObject;
 import org.springframework.http.HttpStatus;
@@ -11,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.org.jenkins.custom.jenkins.distribution.service.generators.PackageConfigGenerator.generatePackageConfig;
-
 @RestController
 @CrossOrigin
 @RequestMapping("/package")
@@ -31,6 +31,18 @@ public class PackagerController {
             return new ResponseEntity<>(yamlResponse, HttpStatus.OK);
         } catch (Exception e) {
             LOGGER.severe(e.toString());
+            return new ResponseEntity(HttpStatus.NOT_FOUND);
+        }
+    }
+
+    @PostMapping (path = "/downloadWarPackage")
+    public ResponseEntity<?> downloadPackageConfig(@RequestBody String postPayload) {
+        LOGGER.info("Request Received for downloading war file with configuration" + postPayload);
+        try {
+            return new PackagerDownloadService().downloadWAR("0.1", postPayload);
+        } catch (Exception e) {
+            LOGGER.severe(e.toString());
+            e.printStackTrace();
             return new ResponseEntity(HttpStatus.NOT_FOUND);
         }
     }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
@@ -41,14 +41,17 @@ public class PackagerController {
         }
     }
 
+    /**
+     * @param postPayload Configuration for the war file
+     * @return War file
+     */
     @PostMapping (path = "/downloadWarPackage")
-    public ResponseEntity<?> downloadPackageConfig(@RequestBody String postPayload) {
-        LOGGER.info("Request Received for downloading war file with configuration" + postPayload);
+    public ResponseEntity<?> downloadWAR(@RequestBody String postPayload) {
+        LOGGER.info("Request Received for downloading war file with configuration");
         try {
             return new PackagerDownloadService().downloadWAR(getWarVersion(), postPayload);
         } catch (Exception e) {
             LOGGER.severe(e.toString());
-            e.printStackTrace();
             return new ResponseEntity(HttpStatus.NOT_FOUND);
         }
     }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
@@ -1,6 +1,9 @@
 package com.org.jenkins.custom.jenkins.distribution.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.org.jenkins.custom.jenkins.distribution.service.services.PackagerDownloadService;
+import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
+import java.util.Map;
 import java.util.logging.Logger;
 import org.json.JSONObject;
 import org.springframework.http.HttpStatus;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.yaml.snakeyaml.Yaml;
 
 import static com.org.jenkins.custom.jenkins.distribution.service.generators.PackageConfigGenerator.generatePackageConfig;
 @RestController
@@ -17,6 +21,8 @@ import static com.org.jenkins.custom.jenkins.distribution.service.generators.Pac
 @RequestMapping("/package")
 
 public class PackagerController {
+
+    private static Util util = new Util();
 
     private final static Logger LOGGER = Logger.getLogger(PackagerController.class.getName());
     /*
@@ -39,11 +45,18 @@ public class PackagerController {
     public ResponseEntity<?> downloadPackageConfig(@RequestBody String postPayload) {
         LOGGER.info("Request Received for downloading war file with configuration" + postPayload);
         try {
-            return new PackagerDownloadService().downloadWAR("0.1", postPayload);
+            return new PackagerDownloadService().downloadWAR(getWarVersion(), postPayload);
         } catch (Exception e) {
             LOGGER.severe(e.toString());
             e.printStackTrace();
             return new ResponseEntity(HttpStatus.NOT_FOUND);
         }
+    }
+
+    private String getWarVersion() throws Exception {
+        Yaml yaml = new Yaml();
+        Map<String , Map<String,String>> yamlMaps = (Map<String, Map<String,String>>) yaml.load(util.readStringFromFile("packager-config.yml"));
+        JSONObject json = new JSONObject(new ObjectMapper().writeValueAsString(yamlMaps.get("war")));
+        return json.getJSONObject("source").get("version").toString();
     }
 }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
@@ -13,7 +13,7 @@ public class WarGenerator {
     private static final String TEMP_PREFIX = "CDS";
 
 
-    public static File generateWAR(String versionName, String configuration, String artifactID) throws Exception {
+    public static File generateWAR(String versionName, String configuration) throws Exception {
         LOGGER.info("Generating War File");
         final Config cfg;
         Path tempDirWithPrefix = Files.createTempDirectory(TEMP_PREFIX);
@@ -27,7 +27,7 @@ public class WarGenerator {
             new Builder(cfg).build();
             LOGGER.info("Cleaning up temporary directory");
             packagerConfigFile.deleteOnExit();
-            return new File("/tmp/output/target/" + artifactID + "-" + versionName + ".war");
+            return cfg.getOutputWar();
     }
 
 }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
@@ -7,25 +7,30 @@ import io.jenkins.tools.warpackager.lib.impl.Builder;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.logging.Logger;
 
 public class WarGenerator {
 
+    private final static Logger LOGGER = Logger.getLogger(WarGenerator.class.getName());
     private static Util util = new Util();
-
-    private static final String PACKAGER_CONFIG_YAML = "packager-config.yml";
     private static final String TEMP_PREFIX = "CDS";
 
-    public static void generateWAR(String versionName) {
+    public static void generateWAR(String versionName, String configuration) {
+        LOGGER.info("Generating War File");
         final Config cfg;
         Path tempDirWithPrefix = null;
         try {
             tempDirWithPrefix = Files.createTempDirectory(TEMP_PREFIX);
-            final File configPath = util.getFileFromResources(PACKAGER_CONFIG_YAML);
-            cfg = Config.loadConfig(configPath);
+            File packagerConfigFile = File.createTempFile("packager-config", ".yml");
+            byte[] buf = configuration.getBytes();
+            Files.write(packagerConfigFile.toPath(), buf);
+            cfg = Config.loadConfig(packagerConfigFile);
             cfg.buildSettings.setTmpDir(tempDirWithPrefix.toFile());
             cfg.buildSettings.setVersion(versionName);
             cfg.buildSettings.setInstallArtifacts(true);
             new Builder(cfg).build();
+            LOGGER.info("Cleaning up temporary directory");
+            packagerConfigFile.deleteOnExit();
         } catch (Exception e) {
             e.printStackTrace();
         } finally {

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
@@ -1,9 +1,7 @@
 package com.org.jenkins.custom.jenkins.distribution.service.generators;
 
-import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
 import io.jenkins.tools.warpackager.lib.config.Config;
 import io.jenkins.tools.warpackager.lib.impl.Builder;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,15 +10,13 @@ import java.util.logging.Logger;
 public class WarGenerator {
 
     private final static Logger LOGGER = Logger.getLogger(WarGenerator.class.getName());
-    private static Util util = new Util();
     private static final String TEMP_PREFIX = "CDS";
 
-    public static void generateWAR(String versionName, String configuration) {
+
+    public static File generateWAR(String versionName, String configuration, String artifactID) throws Exception {
         LOGGER.info("Generating War File");
         final Config cfg;
-        Path tempDirWithPrefix = null;
-        try {
-            tempDirWithPrefix = Files.createTempDirectory(TEMP_PREFIX);
+        Path tempDirWithPrefix = Files.createTempDirectory(TEMP_PREFIX);
             File packagerConfigFile = File.createTempFile("packager-config", ".yml");
             byte[] buf = configuration.getBytes();
             Files.write(packagerConfigFile.toPath(), buf);
@@ -31,10 +27,7 @@ public class WarGenerator {
             new Builder(cfg).build();
             LOGGER.info("Cleaning up temporary directory");
             packagerConfigFile.deleteOnExit();
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            util.cleanupTempDirectory(tempDirWithPrefix.toFile());
-        }
+            return new File("/tmp/output/target/" + artifactID + "-" + versionName + ".war");
     }
+
 }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
@@ -1,5 +1,6 @@
 package com.org.jenkins.custom.jenkins.distribution.service.services;
 
+import com.org.jenkins.custom.jenkins.distribution.service.generators.WarGenerator;
 import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,10 +20,11 @@ public class PackagerDownloadService {
     private final static Logger LOGGER = Logger.getLogger(PackagerDownloadService.class.getName());
     private static Util util = new Util();
 
-    public ResponseEntity<Resource> downloadWAR(String versionName) throws Exception {
+    public ResponseEntity<Resource> downloadWAR(String versionName, String configuration) throws Exception {
         File warFile = null;
         String artifactId = getArtifactId();
         try {
+            WarGenerator.generateWAR(versionName, configuration);
             warFile = new File("/tmp/output/target/" + artifactId + "-" + versionName + ".war");
             InputStreamResource resource = new InputStreamResource(new FileInputStream(warFile));
             String headerValue = "attachment; filename=jenkins.war";

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
@@ -1,11 +1,13 @@
 package com.org.jenkins.custom.jenkins.distribution.service.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.org.jenkins.custom.jenkins.distribution.service.generators.WarGenerator;
 import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.json.JSONObject;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -24,8 +26,7 @@ public class PackagerDownloadService {
         File warFile = null;
         String artifactId = getArtifactId();
         try {
-            WarGenerator.generateWAR(versionName, configuration);
-            warFile = new File("/tmp/output/target/" + artifactId + "-" + versionName + ".war");
+            warFile = WarGenerator.generateWAR(versionName, configuration, artifactId);
             InputStreamResource resource = new InputStreamResource(new FileInputStream(warFile));
             String headerValue = "attachment; filename=jenkins.war";
             LOGGER.info("Returning War file");
@@ -55,12 +56,12 @@ public class PackagerDownloadService {
         return headers;
     }
 
-
     private String getArtifactId() throws Exception {
         Yaml yaml = new Yaml();
         Map<String , Map<String,String>> yamlMaps = (Map<String, Map<String,String>>) yaml.load(util.readStringFromFile("packager-config.yml"));
-        String artifactId = yamlMaps.get("bundle").get("artifactId");
-        return artifactId;
+        return yamlMaps.get("bundle").get("artifactId");
     }
+
+
 }
 

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
@@ -26,7 +26,7 @@ public class PackagerDownloadService {
         File warFile = null;
         String artifactId = getArtifactId();
         try {
-            warFile = WarGenerator.generateWAR(versionName, configuration, artifactId);
+            warFile = WarGenerator.generateWAR(versionName, configuration);
             InputStreamResource resource = new InputStreamResource(new FileInputStream(warFile));
             String headerValue = "attachment; filename=jenkins.war";
             LOGGER.info("Returning War file");

--- a/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
+++ b/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
@@ -1,12 +1,21 @@
 package com.org.jenkins.custom.jenkins.distribution.service.generators;
 
+import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
 import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.util.AssertionErrors.fail;
 
 public class WarGeneratorTest {
 
+    Util util = new Util();
+
     @Test
     public void testWarGenerationSucceeds() {
-        WarGenerator.generateWAR("1.0");
+        try {
+            WarGenerator.generateWAR("1.0", util.readStringFromFile("packager-config.yml") );
+        } catch (Exception e) {
+            fail("Should not have thrown any exception");
+        }
     }
 
 }

--- a/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
+++ b/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
@@ -12,9 +12,9 @@ public class WarGeneratorTest {
     @Test
     public void testWarGenerationSucceeds() {
         try {
-            WarGenerator.generateWAR("1.0", util.readStringFromFile("packager-config.yml") );
+            WarGenerator.generateWAR("1.0", util.readStringFromFile("packager-config.yml"), "jenkins-all-latest" );
         } catch (Exception e) {
-            fail("Should not have thrown any exception");
+            fail("Should not have thrown any exception" + e);
         }
     }
 

--- a/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
+++ b/src/test/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGeneratorTest.java
@@ -12,7 +12,7 @@ public class WarGeneratorTest {
     @Test
     public void testWarGenerationSucceeds() {
         try {
-            WarGenerator.generateWAR("1.0", util.readStringFromFile("packager-config.yml"), "jenkins-all-latest" );
+            WarGenerator.generateWAR("jenkins-all-latest", util.readStringFromFile("packager-config.yml"));
         } catch (Exception e) {
             fail("Should not have thrown any exception" + e);
         }

--- a/src/test/resources/packagerConfig/simpleConfig.yml
+++ b/src/test/resources/packagerConfig/simpleConfig.yml
@@ -9,9 +9,9 @@ casc:
     dir: "casc.yml"
 plugins:
 - groupId: "org.jenkins-ci.plugins"
-  artifactId: "AnchorChain"
+  artifactId: "dotnet-as-script"
   source:
-    version: "1.0"
+    version: "1.0.2"
 - groupId: "org.jenkins-ci.plugins"
   artifactId: "ApicaLoadtest"
   source:


### PR DESCRIPTION
Right now maven enforcer is not enabled in the code. The project is just malfunctional in #68 due to dependency. CWP will not really work due to the binary conflict in Maven versions.

```
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (display-info) @ custom-distribution-service ---
[INFO] Adding ignore: module-info
[INFO] Ignoring requireUpperBoundDeps in commons-logging:commons-logging
[WARNING] Rule 3: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.sonatype.sisu:sisu-guice:jar:noaop:2.1.7
Found Banned Dependency: commons-logging:commons-logging:jar:1.0.4
Use 'mvn dependency:tree' to locate the source of the banned dependencies.
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.apache.maven:maven-model:3.0 paths to dependency are:
+-io.jenkins.tools.distribution-service:custom-distribution-service:0.0.1
  +-org.apache.maven.plugins:maven-dependency-plugin:3.1.1
    +-org.apache.maven:maven-model:3.0
and
+-io.jenkins.tools.distribution-service:custom-distribution-service:0.0.1
  +-io.jenkins.tools.custom-war-packager:custom-war-packager-lib:1.7
    +-org.apache.maven:maven-model:3.5.0
```

