### PR TITLE
Pin maven Surefire Plugin +  Add Maven Enforcer + Remove maven dependency plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,12 @@
 			<artifactId>json</artifactId>
 			<version>20200518</version>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-dependency-plugin</artifactId>
-			<version>3.1.1</version>
-		</dependency>
+<!--		&lt;!&ndash; Why do we bundle the Maven Plugin??? &ndash;&gt;-->
+<!--		<dependency>-->
+<!--			<groupId>org.apache.maven.plugins</groupId>-->
+<!--			<artifactId>maven-dependency-plugin</artifactId>-->
+<!--			<version>3.1.1</version>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
@@ -94,9 +95,113 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M5</version>
+				<configuration>
+					<!-- SUREFIRE-1226 workaround -->
+					<trimStackTrace>false</trimStackTrace>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>display-info</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>display-info</goal>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.3.1,)</version>
+                  <message>3.3.1 required to at least look at .mvn/ if it exists.</message>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8.0,)</version>
+                </requireJavaVersion>
+                <!-- TODO failing during incrementals deploy: MENFORCER-281
+                <requirePluginVersions>
+                  <banSnapshots>false</banSnapshots>
+                </requirePluginVersions>
+                -->
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.8</maxJdkVersion>
+                  <ignoredScopes>
+                    <ignoredScope>test</ignoredScope>
+                  </ignoredScopes>
+                  <excludes>
+                    <!-- Makes no sense to check core itself: -->
+                    <exclude>org.jenkins-ci.main:jenkins-core</exclude>
+                    <exclude>org.jenkins-ci.main:cli</exclude>
+                    <exclude>org.jenkins-ci.main:jenkins-test-harness</exclude>
+                    <exclude>org.jenkins-ci.main:remoting</exclude>
+                    <exclude>org.kohsuke.stapler:stapler</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-groovy</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jelly</exclude>
+                    <exclude>org.kohsuke.stapler:stapler-jrebel</exclude>
+                    <exclude>org.jenkins-ci:task-reactor</exclude>
+                    <!--  findbugs dep managed to provided and optional so is not shipped and missing annotations ok -->
+                    <exclude>com.google.code.findbugs:annotations</exclude>
+                    <exclude>com.github.spotbugs:spotbugs-annotations</exclude>
+                  </excludes>
+                  <!-- To add exclusions in a Jenkins plugin, use:
+                  <plugin>
+                      <artifactId>maven-enforcer-plugin</artifactId>
+                      <executions>
+                          <execution>
+                              <id>display-info</id>
+                              <configuration>
+                                  <rules>
+                                      <enforceBytecodeVersion>
+                                          <excludes combine.children="append">
+                                              <exclude>…</exclude>
+                                          </excludes>
+                                      </enforceBytecodeVersion>
+                                  </rules>
+                              </configuration>
+                          </execution>
+                      </executions>
+                  </plugin>
+                  (or just override java.level) -->
+                </enforceBytecodeVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>javax.servlet:servlet-api</exclude>
+                    <exclude>org.sonatype.sisu:sisu-guice</exclude>
+                    <exclude>log4j:log4j:*:jar:compile</exclude>
+                    <exclude>log4j:log4j:*:jar:runtime</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:compile</exclude>
+                    <exclude>commons-logging:commons-logging:*:jar:runtime</exclude>
+                    <!-- Jenkins Test Harness is based on JUnit. Adding TestNG dependency would disable some of its functionality. -->
+                    <exclude>org.testng:testng</exclude>
+                  </excludes>
+                </bannedDependencies>
+                <requireUpperBoundDeps>
+                  <excludes>
+                    <exclude>com.google.guava:guava</exclude> <!-- TODO needed for Jenkins 2.71 and earlier -->
+                    <exclude>commons-logging:commons-logging</exclude> <!-- ditto -->
+                    <exclude>com.google.code.findbugs:jsr305</exclude> <!-- ditto -->
+                    <exclude>net.java.dev.jna:jna</exclude> <!-- needed for Jenkins 1.585 and earlier -->
+                  </excludes>
+                </requireUpperBoundDeps>
+              </rules>
+            </configuration>
+          </execution>
+		          </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Right now maven enforcer is not enabled in the code. The project is just malfunctional in #68 due to dependency. CWP will not really work due to the binary conflict in Maven versions. This has been fixed by removing the maven dependency plugin