### PR TITLE
Exclude extra json library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
 					<groupId>org.junit.vintage</groupId>
 					<artifactId>junit-vintage-engine</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.vaadin.external.google</groupId>
+					<artifactId>android-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This PR excludes the extra `vaadin` json library that is not required.
The best solution seems to exclude the unnecessary library 
https://stackoverflow.com/questions/52980064/maven-spring-boot-found-multiple-occurrences-of-org-json-jsonobject-on-the-cl

Closes #114 