### PR TITLE
Remove JCasC section from packager generation

### DIFF
--- a/frontend/src/components/modal.js
+++ b/frontend/src/components/modal.js
@@ -42,6 +42,7 @@ class ModalExample extends React.Component {
         // Add war object
         packagerInfo["war"] = {jenkinsVersion: this.state.warVersion}
         // Make the casc section permanently false since no support for it
+        // https://github.com/jenkinsci/custom-distribution-service/issues/117 (Support Ticket)
         packagerInfo["casc"] = false
         // Add plugin object
         packagerInfo["plugins"] = JSON.parse(localStorage.getItem("pluginsArray"))

--- a/frontend/src/components/modal.js
+++ b/frontend/src/components/modal.js
@@ -41,7 +41,8 @@ class ModalExample extends React.Component {
         packagerInfo["bundle"] = bundle
         // Add war object
         packagerInfo["war"] = {jenkinsVersion: this.state.warVersion}
-        packagerInfo["casc"] = true
+        // Make the casc section permanently false since no support for it
+        packagerInfo["casc"] = false
         // Add plugin object
         packagerInfo["plugins"] = JSON.parse(localStorage.getItem("pluginsArray"))
         // Add buildSettings object
@@ -129,6 +130,8 @@ class ModalExample extends React.Component {
                         onChange={ (e) => this.handleChange(e) }
                      />
                     </FormGroup>  
+                    {/* Disable this section for now since we do 
+                    not have support for JCaSC 
                     <FormGroup check>
                         <Label check>
                         <Input 
@@ -137,7 +140,7 @@ class ModalExample extends React.Component {
                          onChange={ (e) => this.handleChange(e) }/>{' '}
                         Include Configuration as Code Section
                         </Label>
-                    </FormGroup>   
+                    </FormGroup>    */}
                     <FormGroup>
                     <legend>Build Settings</legend>
                     <Label for = "dockertag">Docker Build</Label>


### PR DESCRIPTION
This PR removes the JCasC section because we currently do not have support for it which causes the war generation to fail. 
![Screenshot from 2020-08-13 14-13-47](https://user-images.githubusercontent.com/28837406/90113683-57a8a580-dd6f-11ea-8559-6d1284165ae4.png)
