### PR TITLE
Fix war generation in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /build/
 # Runs the mvn package command to compile and package the application as an executable JAR
 RUN mvn clean package spring-boot:repackage
 
-FROM openjdk:8-jre-alpine
+FROM maven:3.6.0-jdk-8-alpine
 
 # Create a new working directory in the image called /app
 WORKDIR /app

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/PackagerController.java
@@ -1,11 +1,9 @@
 package com.org.jenkins.custom.jenkins.distribution.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.org.jenkins.custom.jenkins.distribution.service.services.PackagerDownloadService;
 import com.org.jenkins.custom.jenkins.distribution.service.util.Util;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 import java.io.ByteArrayInputStream;
 import java.util.logging.Logger;
 import org.json.JSONObject;
@@ -17,15 +15,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.yaml.snakeyaml.Yaml;
 
 import static com.org.jenkins.custom.jenkins.distribution.service.generators.PackageConfigGenerator.generatePackageConfig;
 @RestController
 @CrossOrigin
 @RequestMapping("/package")
 public class PackagerController {
-
-    private static Util util = new Util();
 
     private final static Logger LOGGER = Logger.getLogger(PackagerController.class.getName());
 
@@ -67,7 +62,7 @@ public class PackagerController {
     public ResponseEntity<?> downloadWAR(@RequestBody final String postPayload) {
         LOGGER.info("Request Received for downloading war file with configuration" + postPayload);
         try {
-            return new PackagerDownloadService().downloadWAR(getWarVersion(), postPayload);
+            return new PackagerDownloadService().downloadWAR(postPayload);
         } catch (IOException | InterruptedException e) {
             LOGGER.severe(e.toString());
             return new ResponseEntity(HttpStatus.NOT_FOUND);
@@ -89,13 +84,4 @@ public class PackagerController {
             return Util.returnResource(Util.returnHeaders(headerValue), postPayload.getBytes(StandardCharsets.UTF_8).length, resource);
     }
 
-    private String getWarVersion() throws IOException {
-        final Yaml yaml = new Yaml();
-        final JSONObject json;
-
-        final Map<String, Map<String, String>> yamlMaps = (Map<String, Map<String, String>>) yaml.load(util.readStringFromFile("packager-config.yml"));
-        json = new JSONObject(new ObjectMapper().writeValueAsString(yamlMaps.get("war")));
-
-        return json.getJSONObject("source").get("version").toString();
-    }
 }

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/generators/WarGenerator.java
@@ -6,27 +6,22 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.logging.Logger;
 
 @SuppressWarnings("PMD.LawOfDemeter")
 public class WarGenerator {
 
     private final static Logger LOGGER = Logger.getLogger(WarGenerator.class.getName());
-    private static final String TEMP_PREFIX = "CDS";
 
 
-    public static File generateWAR(final String versionName, final String configuration) throws IOException, InterruptedException {
+    public static File generateWAR(final String configuration) throws IOException, InterruptedException {
         LOGGER.info("Generating War File");
         final Config cfg;
-        final Path tempDirWithPrefix = Files.createTempDirectory(TEMP_PREFIX);
-            final File packagerFile = File.createTempFile("packager-config", ".yml");
+        final File packagerFile = File.createTempFile("packager-config", ".yml");
             final byte[] buf = configuration.getBytes(StandardCharsets.UTF_8);
             Files.write(packagerFile.toPath(), buf);
             cfg = Config.loadConfig(packagerFile);
-        
-            cfg.buildSettings.setTmpDir(tempDirWithPrefix.toFile());
-            cfg.buildSettings.setVersion(versionName);
+            cfg.buildSettings.setVersion(cfg.buildSettings.getVersion());
             cfg.buildSettings.setInstallArtifacts(true);
             new Builder(cfg).build();
             LOGGER.info("Cleaning up temporary directory");

--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/services/PackagerDownloadService.java
@@ -21,15 +21,15 @@ public class PackagerDownloadService {
     private static Util util = new Util();
 
     /**
-     * @param versionName This is the version name of the war file eg: jenkins-all-latest
      * @param configuration This is the configuration with which the war is generated.
      * @return Response Entity with body as the war file in the form of a resource
      * @throws Exception
      */
-    public ResponseEntity<Resource> downloadWAR(final String versionName, final String configuration) throws IOException, InterruptedException {
+    public ResponseEntity<Resource> downloadWAR(final String configuration) throws IOException, InterruptedException {
         File warFile = null;
         try {
-            warFile = WarGenerator.generateWAR(versionName, configuration);
+            LOGGER.info("We are about to enter the war generator function");
+            warFile = WarGenerator.generateWAR(configuration);
             final InputStreamResource resource = new InputStreamResource(Files.newInputStream(Paths.get(warFile.getAbsolutePath())));
             final String headerValue = "attachment; filename=jenkins.war";
             LOGGER.info("Returning War file");


### PR DESCRIPTION
This PR tries to fix the generation of war file in docker-compose.
I solved one of the issues where the `packager.config.yml` was not available in the docker container because we are storing it in a temporary file and it is not available until war generation. So picked up the version name from the cfg variable provided by custom war packager.
However we run into another issue namely
```
app-server_1  | 2020-08-21 10:19:00.165 ERROR 1 --- [nio-8080-exec-1] c.o.j.c.j.d.service.PackagerController   : java.io.IOException: Cannot run program "mvn" (in directory "tmp/prebuild"): error=2, No such file or directory
```

CC @oleg-nenashev 
