### PR TITLE
Mime types were not set by default, so enable the mime factory

### DIFF
--- a/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/MimeMapping.java
+++ b/src/main/java/com/org/jenkins/custom/jenkins/distribution/service/MimeMapping.java
@@ -1,0 +1,15 @@
+package com.org.jenkins.custom.jenkins.distribution.service;
+
+import org.springframework.boot.web.server.MimeMappings;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MimeMapping implements WebServerFactoryCustomizer<ConfigurableServletWebServerFactory> {
+    @Override
+    public void customize(final ConfigurableServletWebServerFactory factory) {
+        final MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
+        factory.setMimeMappings(mappings);
+    }
+}


### PR DESCRIPTION
jenkins.io has tighter restrictions on mime types so i didn't notice it on early testing

Before:

![image](https://user-images.githubusercontent.com/110087/91114190-2f0c8f80-e63c-11ea-8557-2092c3db18aa.png)

After:

![image](https://user-images.githubusercontent.com/110087/91114208-3af85180-e63c-11ea-96dc-945e7fa11956.png)
