### PR TITLE
Updated pluginCard layout

### DIFF
--- a/frontend/src/components/layouts/CardLayout.js
+++ b/frontend/src/components/layouts/CardLayout.js
@@ -25,7 +25,7 @@ const DEFAULT_SORT_TYPES = [
     ['updated', 'Release date']
 ]
 
-const DEFAULT_CARDS_PER_PAGE = 10
+const DEFAULT_CARDS_PER_PAGE = 12
 
 const CardLayout = ({
     setConfiguration,
@@ -75,13 +75,13 @@ const CardLayout = ({
     // Create index array
     const indexArray = []
     // Calculate first index
-    let lastIndex = indexOfFirstData / 10 + 1     
+    let lastIndex = indexOfFirstData / 12 + 1     
 
     let firstIndex = 0
-    if (lastIndex >= 10 ) {
-        firstIndex = lastIndex - 10
+    if (lastIndex >= 12 ) {
+        firstIndex = lastIndex - 12
     } else {
-        lastIndex = 9
+        lastIndex = 11
     }
 
     let counter = 0
@@ -108,7 +108,7 @@ const CardLayout = ({
         return true
     }).map(data => {
         return (
-            <Col sm="3" key={ data.name }>
+            <Col sm="4" key={ data.name }>
                 {cardInstanceFunc({ data, setConfiguration })} 
             </Col>
         )


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR does the following changes:
- Displays 3 plugin cards per row (currently, there are 4 plugin cards/row)
- Displays a total of 12 plugin cards on each page (currently, there are 10 plugin cards/page)
- In the pagination section, there are 12-page numbers visible (currently, there are 10-page numbers)

This PR aims to:
- Give more space to each plugin card to improve its readability, and make it look neater.
- Utilise currently unused space of 2 cards (at the bottom of each page), and display cards in that place as well.

Screenshots:
- Before
![jenkins_before](https://user-images.githubusercontent.com/43273420/110152620-f843dd00-7e07-11eb-9cb7-b013a34f6aca.png)

- After
![jenkins_after](https://user-images.githubusercontent.com/43273420/110152636-fd089100-7e07-11eb-8e22-cfbe148c2b88.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
